### PR TITLE
Add rapid editor to default editor dropdown in user preferences

### DIFF
--- a/app/views/site/_rapid.html.erb
+++ b/app/views/site/_rapid.html.erb
@@ -1,4 +1,7 @@
 <script>
+  // Using the edit button, the URL for this page will be…
+  // /edit#map=18/38.89685/-76.97983
+  // /edit?editor=rapid#map=18/38.89685/-76.97983
   const urlHash = new URLSearchParams(window.location.hash.substring(1));
   const urlHashMapParam = urlHash.get('map');
   const editUrl = 'https://rapideditor.org/edit#map=' + urlHashMapParam;

--- a/app/views/site/_rapid.html.erb
+++ b/app/views/site/_rapid.html.erb
@@ -1,0 +1,7 @@
+<script>
+  const urlHash = new URLSearchParams(window.location.hash.substring(1));
+  const urlHashMapParam = urlHash.get('map');
+  const editUrl = 'https://rapideditor.org/edit#map=' + urlHashMapParam;
+
+  window.location.href = editUrl;
+</script>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -203,6 +203,9 @@ en:
     id:
       name: "iD"
       description: "iD (in-browser editor)"
+    rapid:
+      name: "Rapid"
+      description: "Rapid (in-browser editor)"
     remote:
       name: "Remote Control"
       description: "Remote Control (JOSM, Potlatch, Merkaartor)"

--- a/lib/editors.rb
+++ b/lib/editors.rb
@@ -1,5 +1,8 @@
 module Editors
-  ALL_EDITORS = %w[potlatch potlatch2 id remote].freeze
-  AVAILABLE_EDITORS = %w[id remote].freeze
+  # for validations
+  ALL_EDITORS = %w[potlatch potlatch2 id rapid remote].freeze
+  # for /preferences/edit
+  AVAILABLE_EDITORS = %w[id rapid remote].freeze
+  # for the main menu dropdown
   RECOMMENDED_EDITORS = %w[id remote].freeze
 end


### PR DESCRIPTION
This will add the option to select Rapid as default editor in the user preferences at `/preferences/edit`. It _will not_ add it to the recommended editors on the main edit menu.

**Preferences:**
<img width="869" alt="image" src="https://github.com/tordans/openstreetmap-website/assets/111561/e3be7667-8d57-434a-9ca2-6155a65c7cc6">

**Edit Menu:**
<img width="867" alt="image" src="https://github.com/tordans/openstreetmap-website/assets/111561/827543ce-e0de-457c-be35-13e463cdb199">

----

`TODO PART ABOUT Editor Inclusion Policy`

----

**Implementation details:**

Rapid is integrated as an external editor that loads under the rapid domain. This can be done in different ways. I chose to add the `script` tag directly in `_rapid.html.erb` to keep the related code tight together in one place which has more advantages than disadvantages IMO.

- [ ] **TODO**: Apparently script tags are an issue, see https://github.com/openstreetmap/openstreetmap-website/pull/4402#issuecomment-1853461760